### PR TITLE
fix cron tests

### DIFF
--- a/tests/e2e/execute-tests.sh
+++ b/tests/e2e/execute-tests.sh
@@ -34,7 +34,7 @@ function run_deploy_and_tests() {
 
     set -e
     pytest "tests/e2e/${TEST_TYPE}" -v
-    if [[ $TRAVIS_BRANCH == 'master' ]]; then
+    if [[ $TRAVIS_BRANCH == 'master' ]] && [[ $TEST_TYPE != 'logs' ]]; then
         performance_test
     fi
 }


### PR DESCRIPTION
cron tests are failing, because at first, they are running gcp monitor only with logs container 