### PR TITLE
Pclouds 2240 change docker user

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -23,4 +23,8 @@ WORKDIR /code
 COPY --from=build /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 COPY src/ .
 COPY LICENSE.md /licenses/
+
+RUN adduser --disabled-password gcp-monitor && chown -R gcp-monitor /code
+USER gcp-monitor
+
 CMD [ "python", "-u", "./run_docker.py" ]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 # metrics
-aiohttp==3.8.0
+aiohttp==3.8.4
 aiodns==2.0.0
 mmh3==2.5.1
 PyJWT==2.4.0


### PR DESCRIPTION
- The latest version of aiohttps doesn't contain an examples folder with a secret key: /usr/local/lib/python3.8/site-packages/examples/server.key
- gcp monitor is now running under the gcp-monitor user, not root(as it was prev)