### PR TITLE
feat: added excluded_projects_by_prefix/substring capability (#436)

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
@@ -28,6 +28,7 @@ data:
   {{- end }}
   SCOPING_PROJECT_SUPPORT_ENABLED: {{ .Values.scopingProjectSupportEnabled | quote }}
   EXCLUDED_PROJECTS: {{ .Values.excludedProjects | quote }}
+  EXCLUDED_PROJECTS_BY_PREFIX: {{ .Values.excludedProjectsByPrefix | quote }}
   KEEP_REFRESHING_EXTENSIONS_CONFIG: {{ .Values.keepRefreshingExtensionsConfig | quote }}
   {{- if or (eq .Values.deploymentType "metrics") (eq .Values.deploymentType "all") }}
   PRINT_METRIC_INGEST_INPUT: {{ .Values.printMetricIngestInput | quote }}

--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-deployment.yml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-deployment.yml
@@ -139,6 +139,12 @@ spec:
             configMapKeyRef:
               name: dynatrace-gcp-monitor-config
               key: EXCLUDED_PROJECTS
+        - name: EXCLUDED_PROJECTS_BY_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-monitor-config
+              key: EXCLUDED_PROJECTS_BY_PREFIX
+
         - name:   KEEP_REFRESHING_EXTENSIONS_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
@@ -120,6 +120,9 @@ clusterName: ""
 scopingProjectSupportEnabled: "false"
 # excludedProjects: comma separated list of projects that will be excluded from monitoring (e.g. "project-a,project-b,project-c").
 excludedProjects: ""
+# excludedProjectsByPrefix: comma separated list of projects substring that will be excluded from monitoring (e.g. "project-a,proj,pro").
+excludedProjectsByPrefix: ""
+
 metricResources:
   requests:
     memory: "1536Mi"

--- a/src/lib/configuration/config.py
+++ b/src/lib/configuration/config.py
@@ -17,6 +17,10 @@ def excluded_projects():
     return os.environ.get("EXCLUDED_PROJECTS", "")
 
 
+def excluded_projects_by_prefix():
+    return os.environ.get("EXCLUDED_PROJECTS_BY_PREFIX", "")
+
+
 def project_id():
     return os.environ.get("GCP_PROJECT")
 


### PR DESCRIPTION
* feat: added excluded_projects_by_prefix function for env collecting

* feat: added excluded_projects_by_prefix capability

In addition to the full project_id filter, now this is able to filter by string contained into the project_id. Useful when yo have your GCP envs named with certain maner such as <provider>-<env>-<project>-<random-id> and you have one Dynatrace cluster for each env/proj/***

* feat: added excluded_projects_by_prefix/substring capability

* feat: added excluded_projects_by_prefix/substring capability

* feat: added excluded_projects_by_prefix/substring capability