### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,6 @@ jobs:
       - gcloud components install gke-gcloud-auth-plugin; export USE_GKE_GCLOUD_AUTH_PLUGIN=True; gcloud components update;
     script:
       - mkdir -p ./artefacts/ && gsutil cp gs://travis-e2e/commit-${TRAVIS_COMMIT}_build-${TRAVIS_BUILD_ID}/helm-deployment-package.tar ./artefacts/
-      - travis_wait 60 ./tests/e2e/execute-tests.sh
+      - travis_wait 80 ./tests/e2e/execute-tests.sh
     after_script:
       - ./tests/e2e/deployment-test-cleanup.sh


### PR DESCRIPTION
Cron jobs were already running for almost 1 hour. We added recently 5 mins of delay in each e2e deployment (ref: https://github.com/dynatrace-oss/dynatrace-gcp-monitor/pull/454/files), so 15 minutes are added on each cron run. Thus, I increased this timeout 20 minutes, just in case.