### PR TITLE
PCLOUDS-3941 add log schema alloydb

### DIFF
--- a/src/config_logs/google-alloydb/alloydb_database.json
+++ b/src/config_logs/google-alloydb/alloydb_database.json
@@ -1,0 +1,41 @@
+{
+  "name": "alloydb_database",
+  "displayName": "Google AlloyDB database",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('alloydb.googleapis.com/Database')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "database",
+          "pattern": "resource.labels.database"
+        },
+        {
+          "key": "instance_id",
+          "pattern": "resource.labels.instance_id"
+        },
+        {
+          "key": "cluster_id",
+          "pattern": "resource.labels.cluster_id"
+        },
+        {
+          "key": "gcp.project.id",
+          "pattern": "logName |  split('/', @)[1]"
+        },
+        {
+          "key": "gcp.resource.type",
+          "pattern": "to_string('alloydb_database')"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/google-alloydb/alloydb_instance.json
+++ b/src/config_logs/google-alloydb/alloydb_instance.json
@@ -1,0 +1,37 @@
+{
+  "name": "alloydb_instance",
+  "displayName": "Google AlloyDB instance",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('alloydb.googleapis.com/Instance')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "instance_id",
+          "pattern": "resource.labels.instance_id"
+        },
+        {
+          "key": "cluster_id",
+          "pattern": "resource.labels.cluster_id"
+        },
+        {
+          "key": "gcp.project.id",
+          "pattern": "logName |  split('/', @)[1]"
+        },
+        {
+          "key": "gcp.resource.type",
+          "pattern": "to_string('alloydb_instance')"
+        },
+        {
+          "key": "content",
+          "pattern": "@"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I have to use a logName instead of a resource container because in the second one, google provides project number instead of a project name ID

I don't know if this is a mistake or a deliberate action but this is the easiest solution to circumvent this problem

![image](https://github.com/dynatrace-oss/dynatrace-gcp-monitor/assets/138470854/4faa3cd3-f49d-49a2-b465-f8ff3f121f30)
