### PR TITLE
PCLOUDS-4018 add log schema google compute engine

### DIFF
--- a/src/config_logs/google-compute-engine/autoscaler.json
+++ b/src/config_logs/google-compute-engine/autoscaler.json
@@ -1,0 +1,37 @@
+{
+  "name": "autoscaler",
+  "displayName": "Google Autoscaler",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('autoscaler')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "content",
+          "pattern": "@"
+        },
+        {
+          "key": "gcp.instance.id",
+          "pattern": "resource.labels.autoscaler_id"
+        },
+        {
+          "key": "gcp.instance.name",
+          "pattern": "resource.labels.autoscaler_name"
+        },
+        {
+          "key": "gcp.instance.group.manager.id",
+          "pattern": "resource.labels.instance_group_manager_id"
+        },
+        {
+          "key": "gcp.instance.group.manager.name",
+          "pattern": "resource.labels.instance_group_manager_name"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/google-compute-engine/gce_autoscaler.json
+++ b/src/config_logs/google-compute-engine/gce_autoscaler.json
@@ -1,0 +1,25 @@
+{
+  "name": "gce_autoscaler",
+  "displayName": "Google Autoscaler",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('gce_autoscaler')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "content",
+          "pattern": "@"
+        },
+        {
+          "key": "gcp.instance.id",
+          "pattern": "resource.labels.autoscaler_id"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/google-compute-engine/gce_instance.json
+++ b/src/config_logs/google-compute-engine/gce_instance.json
@@ -1,0 +1,21 @@
+{
+  "name": "gce_instance",
+  "displayName": "Google VM instance",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('gce_instance')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "content",
+          "pattern": "@"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/google-compute-engine/gce_instance_group.json
+++ b/src/config_logs/google-compute-engine/gce_instance_group.json
@@ -1,0 +1,29 @@
+{
+  "name": "gce_instance_group",
+  "displayName": "Google instance group",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('gce_instance_group')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "content",
+          "pattern": "@"
+        },
+        {
+          "key": "gcp.instance.name",
+          "pattern": "resource.labels.instance_group_name"
+        },
+        {
+          "key": "gcp.instance.id",
+          "pattern": "resource.labels.instance_group_id"
+        }
+      ]
+    }
+  ]
+}

--- a/src/config_logs/google-compute-engine/tpu_worker.json
+++ b/src/config_logs/google-compute-engine/tpu_worker.json
@@ -1,0 +1,29 @@
+{
+  "name": "tpu_worker",
+  "displayName": "Google Cloud TPU worker",
+  "rules": [
+    {
+      "sources": [
+        {
+          "sourceType": "logs",
+          "source": "resourceType",
+          "condition": "$eq('tpu_worker')"
+        }
+      ],
+      "attributes": [
+        {
+          "key": "content",
+          "pattern": "@"
+        },
+        {
+          "key": "gcp.instance.id",
+          "pattern": "resource.labels.worker_id"
+        },
+        {
+          "key": "gcp.instance.node_id",
+          "pattern": "resource.labels.node_id"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Problem encountered:
GCP have different resource type for metrics (ex. autoscaler https://cloud.google.com/monitoring/api/resources#tag_autoscaler vs gce_autoscaler https://cloud.google.com/logging/docs/api/v2/resource-list) 