### PR TITLE
[DAQ-4166] Added option to include projects

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
@@ -30,6 +30,8 @@ data:
   SCOPING_PROJECT_SUPPORT_ENABLED: {{ .Values.scopingProjectSupportEnabled | quote }}
   EXCLUDED_PROJECTS: {{ .Values.excludedProjects | quote }}
   EXCLUDED_PROJECTS_BY_PREFIX: {{ .Values.excludedProjectsByPrefix | quote }}
+  INCLUDED_PROJECTS: { { .Values.includedProjects | quote } }
+  INCLUDED_PROJECTS_BY_PREFIX: { { .Values.includedProjectsByPrefix | quote } }
   EXCLUDED_METRICS_AND_DIMENSIONS: {{ .Values.excludedMetricsAndDimensions | quote }}
   LABELS_GROUPING_BY_SERVICE: {{ .Values.labelsGroupingByService | quote }}
   KEEP_REFRESHING_EXTENSIONS_CONFIG: {{ .Values.keepRefreshingExtensionsConfig | quote }}

--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
@@ -30,8 +30,8 @@ data:
   SCOPING_PROJECT_SUPPORT_ENABLED: {{ .Values.scopingProjectSupportEnabled | quote }}
   EXCLUDED_PROJECTS: {{ .Values.excludedProjects | quote }}
   EXCLUDED_PROJECTS_BY_PREFIX: {{ .Values.excludedProjectsByPrefix | quote }}
-  INCLUDED_PROJECTS: { { .Values.includedProjects | quote } }
-  INCLUDED_PROJECTS_BY_PREFIX: { { .Values.includedProjectsByPrefix | quote } }
+  INCLUDED_PROJECTS: {{ .Values.includedProjects | quote }}
+  INCLUDED_PROJECTS_BY_PREFIX: {{ .Values.includedProjectsByPrefix | quote }}
   EXCLUDED_METRICS_AND_DIMENSIONS: {{ .Values.excludedMetricsAndDimensions | quote }}
   LABELS_GROUPING_BY_SERVICE: {{ .Values.labelsGroupingByService | quote }}
   KEEP_REFRESHING_EXTENSIONS_CONFIG: {{ .Values.keepRefreshingExtensionsConfig | quote }}

--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-deployment.yml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-deployment.yml
@@ -177,6 +177,16 @@ spec:
             configMapKeyRef:
               name: dynatrace-gcp-monitor-config
               key: EXCLUDED_PROJECTS_BY_PREFIX
+        - name: INCLUDED_PROJECTS
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-monitor-config
+              key: INCLUDED_PROJECTS
+        - name: INCLUDED_PROJECTS_BY_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-monitor-config
+              key: INCLUDED_PROJECTS_BY_PREFIX
         - name:   KEEP_REFRESHING_EXTENSIONS_CONFIG
           valueFrom:
             configMapKeyRef:

--- a/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
@@ -175,6 +175,10 @@ scopingProjectSupportEnabled: "false"
 excludedProjects: ""
 # excludedProjectsByPrefix: comma separated list of projects substring that will be excluded from monitoring (e.g. "project-a,proj,pro").
 excludedProjectsByPrefix: ""
+# includedProjects: comma separated list of projects that will be included from monitoring (e.g. "project-a,project-b,project-c").
+includedProjects: ""
+# includedProjectsByPrefix: comma separated list of projects substring that will be included from monitoring (e.g. "project-a,proj,pro").
+includedProjectsByPrefix: ""
 # excludedMetricsAndDimensions: structure containing the metrics and dimensions that will be excluded from monitoring.
 # If you want to exclude a metric, add a "metric" entry. Any global metric matching its prefix will not be ingested.
 # If you want to exclude dimensions from a specific metric, add the "metric" entry and specify the dimensions. Selected dimensions will be cut off and the metric will be ingested without them.

--- a/src/lib/configuration/config.py
+++ b/src/lib/configuration/config.py
@@ -49,6 +49,14 @@ def excluded_projects_by_prefix():
     return os.environ.get("EXCLUDED_PROJECTS_BY_PREFIX", "")
 
 
+def included_projects():
+    return os.environ.get("INCLUDED_PROJECTS", "")
+
+
+def included_projects_by_prefix():
+    return os.environ.get("INCLUDED_PROJECTS_BY_PREFIX", "")
+
+
 def project_id():
     return os.environ.get("GCP_PROJECT","")
 

--- a/src/main.py
+++ b/src/main.py
@@ -119,6 +119,8 @@ async def query_metrics(execution_id: Optional[str], services: Optional[List[GCP
 
         disabled_projects = set()
         disabled_projects_by_prefix = set()
+        enabled_projects = set()
+        enabled_projects_by_prefix = set()
         disabled_apis_by_project_id = {}
 
         # Using metrics scope feature, checking disabled apis in every project is not needed
@@ -129,6 +131,9 @@ async def query_metrics(execution_id: Optional[str], services: Optional[List[GCP
         disabled_projects.update(filter(None, config.excluded_projects().split(',')))
         disabled_projects_by_prefix.update(filter(None, config.excluded_projects_by_prefix().split(',')))
 
+        enabled_projects.update(filter(None, config.included_projects().split(',')))
+        enabled_projects_by_prefix.update(filter(None, config.included_projects_by_prefix().split(',')))
+
         if disabled_projects_by_prefix:
             for p in disabled_projects_by_prefix:
                 not_matching = [s for s in projects_ids if p not in s]
@@ -138,6 +143,16 @@ async def query_metrics(execution_id: Optional[str], services: Optional[List[GCP
         if disabled_projects:
             projects_ids = [x for x in projects_ids if x not in disabled_projects]
             context.log("Disabled projects: " + ", ".join(disabled_projects))
+
+        if enabled_projects:
+            projects_ids = [x for x in projects_ids if x in enabled_projects]
+            context.log("Enabled projects: " + ", ".join(enabled_projects))
+
+        if enabled_projects_by_prefix:
+            for p in enabled_projects_by_prefix:
+                matching = [s for s in projects_ids if p in s]
+                projects_ids = matching
+            context.log("Enabled projects: " + ", ".join(enabled_projects_by_prefix))
 
         setup_time = (time.time() - setup_start_time)
         for project_id in projects_ids:


### PR DESCRIPTION
A copy of the community pull request: https://github.com/dynatrace-oss/dynatrace-gcp-monitor/pull/543
A Dynatrace developer responsible for this repository copied and pushed changes to allow the builds to pass. @ajth13 was consulted on the copy and creation of this PR. Thank you once again for your input in the dynatrace-gcp-monitor development. 

Original PR description:

> Where you can currently only exclude projects from monitoring this change adds the ability to specify a list to include.
> Business Justification
> 
> Enterprise customers with a large number of Dynatrace tenants and wants to be able to easily control which metrics are sent to which tenant and include list is much smaller than excluding all projects from other Dynatrace tenants.
> 
> Considerations
> 
> The project must still be included in the metric scoping this only filters the list of scoped projects.
> The exclude logic is preferred so if a project is in both lists it will not be included.