### PR TITLE
DAQ-7853 bump dependencies and python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
     name: Tests
     language: python
     python:
-      - "3.8"
+      - "3.12"
     env:
       - PYTHONPATH="$TRAVIS_BUILD_DIR/src:$TRAVIS_BUILD_DIR/tests"
     addons:
@@ -88,7 +88,7 @@ jobs:
     name: Build
     language: python
     python:
-      - "3.8"
+      - "3.12"
     cache:
       directories:
         - "$HOME/.cache/pip"
@@ -146,7 +146,7 @@ jobs:
     if: (tag =~ /^release-.*/) OR (branch = master) OR (type = pull_request)
     language: python
     python:
-      - "3.8"
+      - "3.12"
     cache:
       directories:
         - "$HOME/.wgetcache"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.8-slim AS build
+FROM python:3.12-slim AS build
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential libffi-dev
 RUN pip install --upgrade pip
 COPY src/requirements.txt .
 RUN pip install -r ./requirements.txt
 
 
-FROM python:3.8-slim
+FROM python:3.12-slim
 
 ARG RELEASE_TAG_ARG
 ENV RELEASE_TAG=$RELEASE_TAG_ARG
@@ -20,7 +20,7 @@ LABEL name="dynatrace-gcp-monitor" \
       description="Dynatrace function for Google Cloud Platform provides the mechanism to pull Google Cloud metrics and logs into Dynatrace."
 
 WORKDIR /code
-COPY --from=build /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY src/ .
 COPY LICENSE.md /licenses/
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -7,7 +7,7 @@ Please note that the following instructions are supported by the community only.
 Feel free to share your ideas back with us, allowing everyone to benefit from the open-source approach.
 
 ## Development environment setup
-To run the worker function locally you have to have the Python dev environment installed: `Python 3.8` with `pip` tool.
+To run the worker function locally you have to have the Python dev environment installed: `Python 3.12` with `pip` tool.
 
 to install all the dependencies run 
 ```shell script

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-flake8==3.8.3
-functions-framework==2.0.0
-mypy==0.782
-pycodestyle==2.6.0
-pylint==2.9.3
+flake8==7.2.0
+functions-framework==3.8.2
+mypy==1.15.0
+pycodestyle==2.13.0
+pylint==3.3.6

--- a/src/lib/instance_metadata.py
+++ b/src/lib/instance_metadata.py
@@ -40,7 +40,7 @@ InstanceMetadata = namedtuple('InstanceMetadata', [
 
 class InstanceMetadataCheck:
 
-    def __init__(self, gcp_session: ClientSession(), token: [str], logging_context: LoggingContext):
+    def __init__(self, gcp_session: ClientSession, token: [str], logging_context: LoggingContext):
         self.gcp_session = gcp_session
         self.token = token
         self.logging_context = logging_context

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,11 +1,11 @@
-setuptools==70.0.0
+setuptools==80.0.0
 # metrics
-aiohttp==3.9.4
+aiohttp==3.10.2
 aiodns==2.0.0
 mmh3==2.5.1
 PyJWT==2.4.0
 cryptography==42.0.4
-PyYAML==5.4
+PyYAML==6.0.2
 # logs
 python-dateutil==2.8.1
 jmespath~=0.10.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,13 +1,13 @@
 setuptools==80.0.0
 # metrics
-aiohttp==3.10.2
-aiodns==2.0.0
-mmh3==2.5.1
-PyJWT==2.4.0
-cryptography==42.0.4
+aiohttp==3.11.18
+aiodns==3.2.0
+mmh3==5.1.0
+PyJWT==2.10.1
+cryptography==44.0.2
 PyYAML==6.0.2
 # logs
-python-dateutil==2.8.1
-jmespath~=0.10.0
-pytz==2022.2.1
-ciso8601==2.3.1
+python-dateutil==2.9.0.post0
+jmespath==1.0.1
+pytz==2025.2
+ciso8601==2.3.2

--- a/src/run_docker.py
+++ b/src/run_docker.py
@@ -49,8 +49,6 @@ if platform.system() == 'Windows':
     policy = asyncio.WindowsSelectorEventLoopPolicy()
     asyncio.set_event_loop_policy(policy)
 
-loop = asyncio.get_event_loop()
-
 PreLaunchCheckResult = NamedTuple('PreLaunchCheckResult', [('services', List[GCPService]), ('extension_versions', Dict[str,str])])
 
 logging_context = LoggingContext(None)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
-setuptools==65.5.1
-pytest==6.2.2
-pytest-asyncio==0.15.1
+setuptools==80.0.0
+pytest==8.3.5
+pytest-asyncio==0.24.0
 wiremock==2.6.1
 pytest-resource-path==1.3.0
 pytest-mock==3.6.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
 setuptools==80.0.0
 pytest==8.3.5
-pytest-asyncio==0.24.0
+pytest-asyncio==0.26.0
 wiremock==2.6.1
 pytest-resource-path==1.3.0
-pytest-mock==3.6.1
-cryptography==42.0.4
-pytz==2022.2.1
-urllib3==1.26.19
+pytest-mock==3.14.0
+cryptography==44.0.2
+pytz==2025.2
+urllib3==2.4.0


### PR DESCRIPTION
- updated runtime and build environment to Python 3.12 (python 3.8 is end-of-life https://devguide.python.org/versions/)
- updated dependencies to latest versions containing latest security fixes