### PR TITLE
feat(autodiscovery): add support for metrics with multiple monitored resource types

### DIFF
--- a/src/lib/autodiscovery/autodiscovery.py
+++ b/src/lib/autodiscovery/autodiscovery.py
@@ -220,13 +220,15 @@ class AutodiscoveryContext:
         autodiscovery_resources_to_metrics = {}
 
         for descriptor, project_ids in discovered_metric_descriptors.items():
-            monitored_resource = descriptor.monitored_resources_types[0]
-            if descriptor.value not in existing_resources_to_metrics[monitored_resource]:
-                autodiscovery_resources_to_metrics.setdefault(monitored_resource, []).append(
-                    Metric(
-                        **(asdict(descriptor)), autodiscovered_metric=True, project_ids=project_ids
-                    )
-                )
+            for monitored_resource in descriptor.monitored_resources_types:
+                if monitored_resource not in existing_resources_to_metrics:
+                    continue
+                if descriptor.value not in existing_resources_to_metrics[monitored_resource]:
+                    autodiscovery_resources_to_metrics.setdefault(monitored_resource, []).append(
+                        Metric(
+                            **(asdict(descriptor)), autodiscovered_metric=True, project_ids=project_ids
+                        )
+                     )
 
         for resource_name, metric_list in autodiscovery_resources_to_metrics.items():
             logging_context.log(

--- a/src/lib/autodiscovery/autodiscovery_utils.py
+++ b/src/lib/autodiscovery/autodiscovery_utils.py
@@ -99,8 +99,10 @@ def should_include_metric(
     should_include = (
         metric_descriptor.gcpOptions.valueType.upper() != "STRING"
         and metric_descriptor.launch_stage != "DEPRECATED"
-        and len(metric_descriptor.monitored_resources_types) == 1
-        and metric_descriptor.monitored_resources_types[0] in resources_to_autodiscover
+        and any(
+            monitored_resources_type in metric_descriptor.monitored_resources_types
+            for monitored_resources_type in resources_to_autodiscover
+        )
         and not any(
             {
                 metric_descriptor.value.startswith(prefix)


### PR DESCRIPTION
This PR addresses an issue where GCP Composer metrics with multiple monitored resource types are not being discovered [see the full list in GCP documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-composer).
 
The current autodiscovery logic is hardcoded to only include metrics with a single monitored_resources_types.

This PR removes this restriction, allowing metrics with multiple monitored_resources_types to be discovered, provided they meet at least one monitored_resources_types is in the resources_to_autodiscover list.