### PR TITLE
fix the return of _get_service_configs_for_extension for non gcp extension

### DIFF
--- a/src/lib/dt_extensions/extensions_fetcher.py
+++ b/src/lib/dt_extensions/extensions_fetcher.py
@@ -113,7 +113,7 @@ class ExtensionsFetcher:
             self.logging_context.log(
                 f"Incorrect extension fetched from Dynatrace cluster. {extension_name}-{extension_version} has no 'gcp' section and will be skipped"
             )
-            return []
+            return [], []
 
         all_services = []
         not_configured_services = []

--- a/tests/unit/lib/dt_extensions/test_extension_fetcher.py
+++ b/tests/unit/lib/dt_extensions/test_extension_fetcher.py
@@ -142,3 +142,27 @@ async def test_extensions_cache():
     assert fetching_call.call_args_list[0].args == (ext_1_name, ext_1_ver1)
     assert fetching_call.call_args_list[1].args == (ext_1_name, ext_1_ver2)
     assert fetching_call.call_args_list[2].args == (ext_2_name, ext_1_ver1)
+
+
+@pytest.mark.asyncio
+async def test_extension_without_gcp_section_is_skipped(monkeypatch: MonkeyPatchFixture):
+    """Test that extensions without a 'gcp' section are skipped without crashing."""
+    monkeypatch.setenv("ACTIVATION_CONFIG", ACTIVATION_CONFIG)
+
+    extensions_fetcher = ExtensionsFetcher(None, None, None, LoggingContext("TEST"))
+
+    # Mock to return extension configuration without 'gcp' section
+    extensions_fetcher.get_extension_configuration_from_cache_or_download = unittest.mock.AsyncMock(
+        return_value={"name": "com.dynatrace.extension.google-big-query", "version": "1.0.0"}
+    )
+
+    services, not_configured = await extensions_fetcher._get_service_configs_for_extension(
+        "com.dynatrace.extension.google-big-query",
+        "1.0.0",
+        {},
+        set(),
+        {}
+    )
+
+    assert services == []
+    assert not_configured == []


### PR DESCRIPTION
When the code downloads an extension that is not GCP, we thrown an exception instead of ignoring the extension

This is breaking the script for a couple of customers, because the code attempts to obtain any extension that contains `com.dynatrace.extension.google`

This fixes the return when that happens, and adds a test case for it

```
2025-12-29 22:09:41.428516 Dynatrace GCP Monitor startup
2025-12-29 22:09:41.428565 GCP Monitor - Dynatrace integration for Google Cloud Platform monitoring

2025-12-29 22:09:41.428706 [webserver] Setting up webserver... 

2025-12-29 22:09:41.429294 Release version: release-1.6.2
2025-12-29 22:09:41.430337 Trying to use default service account
2025-12-29 22:09:41.459740 Resolved host: metadata.google.internal info: [(<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('169.254.169.254', 80)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('169.254.169.254', 80)), (<AddressFamily.AF_INET: 2>, <SocketKind.SOCK_RAW: 3>, 0, '', ('169.254.169.254', 80))]
2025-12-29 22:09:41.503076 GCP instance metadata: InstanceMetadata(project_id=None, container_name='gke-staging-s5b8-spot-new-4-3-node-po-8c4f442f-bdll.c.exa-cloud-staging.internal', token_scopes='https://www.googleapis.com/auth/cloud-platform\nhttps://www.googleapis.com/auth/userinfo.email\n', service_account='default/\ndt-gcp-staging-monit1-sa@exa-cloud-staging-monit1.iam.gserviceaccount.com/\n', audience={'aud': 'https://accounts.google.com/', 'azp': '101878788126329551100', 'email': 'dt-gcp-staging-monit1-sa@exa-cloud-staging-monit1.iam.gserviceaccount.com', 'email_verified': True, 'exp': 1767049781, 'iat': 1767046181, 'iss': 'https://accounts.google.com/', 'sub': '101878788126329551100'}, hostname='dynatrace-gcp-monitor-metrics-staging-monit1-7649db9fdd-k8ccr', zone='us-west1-c')
2025-12-29 22:09:41.504414 Trying to use default service account
2025-12-29 22:09:41.605422 Failed to import a self monitoring dashboard, because: 'NoneType' object is not iterable
2025-12-29 22:09:41.606447 Operation mode: Metrics
2025-12-29 22:09:41.607085 Trying to use default service account
2025-12-29 22:09:41.897136 [EXTENSIONS] Downloading and preparing extension com.dynatrace.extension.google-api (1.0.7)
2025-12-29 22:09:42.000247 [EXTENSIONS] Downloading and preparing extension com.dynatrace.extension.google-big-query (1.0.0)
2025-12-29 22:09:43.180201 [EXTENSIONS] Incorrect extension fetched from Dynatrace cluster. com.dynatrace.extension.google-big-query-1.0.0 has no 'gcp' section and will be skipped
Traceback (most recent call last):
  File "/code/./run_docker.py", line 195, in <module>
    main()
  File "/code/./run_docker.py", line 185, in main
    asyncio.run(run_metrics_fetcher_forever())
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/code/./run_docker.py", line 127, in run_metrics_fetcher_forever
    pre_launch_check_result = await metrics_pre_launch_check()
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/./run_docker.py", line 64, in metrics_pre_launch_check
    extensions_fetch_result = await extensions_fetch(gcp_session, dt_session, token)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/lib/dt_extensions/dt_extensions.py", line 33, in extensions_fetch
    extension_fetcher_result = await ExtensionsFetcher(
                               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/code/lib/dt_extensions/extensions_fetcher.py", line 53, in execute
    services_for_extension, not_configured_services_for_extension = await self._get_service_configs_for_extension(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 0)
stream closed EOF for dynatrace/dynatrace-gcp-monitor-metrics-staging-monit1-7649db9fdd-k8ccr (dynatrace-gcp-monitor-metrics)
```