### PR TITLE
Update Dockerfile and docker-deploy.sh for improved dependency management and authentication setup

### DIFF
--- a/build/docker-deploy.sh
+++ b/build/docker-deploy.sh
@@ -14,16 +14,17 @@
 #     limitations under the License.
 set -eu
 
+# Set up Docker auth for both Docker Hub (push) and dhi.io (hardened base image pull)
+mkdir -p ~/.docker && chmod 0700 ~/.docker
+touch ~/.docker/config.json && chmod 0600 ~/.docker/config.json
+base64 -d >~/.docker/config.json <<<"$OAO_DOCKER_AUTH"
+
 #build container
 ./build/version.sh
 docker build -t dynatrace/dynatrace-gcp-monitor:v1-latest --build-arg RELEASE_TAG_ARG="${TAG}" .
 
 #tag container
 if [[ "${PUSH:-}" == "true" ]]; then
-    mkdir -p ~/.docker && chmod 0700 ~/.docker
-    touch ~/.docker/config.json && chmod 0600 ~/.docker/config.json
-    base64 -d >~/.docker/config.json <<<"$OAO_DOCKER_AUTH"
-
     docker tag dynatrace/dynatrace-gcp-monitor:v1-latest "dynatrace/dynatrace-gcp-monitor:${TAG}"
     docker push dynatrace/dynatrace-gcp-monitor:v1-latest
     docker push "dynatrace/dynatrace-gcp-monitor:${TAG}"


### PR DESCRIPTION
This pull request updates the Docker build and deployment process to use a more secure, hardened base image and improves Docker authentication handling. The most significant changes are grouped below.

**Docker image hardening and dependency management:**

* Switched the base image in the `Dockerfile` from `python:3.12-slim` to `dhi.io/python:3.12-alpine3.23` for both build and runtime stages, using Alpine Linux for a smaller and more secure image with zero known CVEs. Updated dependency installation commands accordingly.
* Added environment variables `PYTHONDONTWRITEBYTECODE=1` and `PYTHONUNBUFFERED=1` in the runtime stage to improve Python container behavior.

**User and permissions improvements:**

* Changed the user creation command to use Alpine's `adduser -D -h /code` and ensured correct ownership of the `/code` directory.

**Docker authentication and deployment script:**

* Moved Docker authentication setup (using the `$OAO_DOCKER_AUTH` secret) to the start of the `build/docker-deploy.sh` script, ensuring credentials are available for both pulling the hardened base image and pushing to Docker Hub.