### PR TITLE
fix: skip failed zone tasks in gce_instance extractor

### DIFF
--- a/src/lib/entities/extractors/gce_instance.py
+++ b/src/lib/entities/extractors/gce_instance.py
@@ -124,6 +124,9 @@ async def get_gce_instance_entity(ctx: MetricsContext, project_id: str, svc_def:
 
     all_results = []
     for result in results:
+        if isinstance(result, Exception):
+            ctx.log(f"gce_instance zone task failed, reason is {type(result).__name__} {result}")
+            continue
         all_results.extend(result)
 
     return all_results

--- a/tests/unit/lib/entities/test_gce_instance.py
+++ b/tests/unit/lib/entities/test_gce_instance.py
@@ -1,0 +1,27 @@
+import asyncio
+from datetime import datetime
+from unittest import mock
+
+from lib.context import MetricsContext
+from lib.entities.extractors import gce_instance
+from lib.metrics import GCPService
+
+
+def _metrics_context() -> MetricsContext:
+    return MetricsContext(None, None, "", "", datetime.utcnow(), 0, "", "", False, False, None)
+
+
+@mock.patch("lib.entities.extractors.gce_instance.generic_paging", new_callable=mock.AsyncMock)
+@mock.patch("lib.entities.extractors.gce_instance.fetch_zones", new_callable=mock.AsyncMock)
+def test_get_gce_instance_entity_skips_failed_zone(mock_fetch_zones, mock_generic_paging):
+    ctx = _metrics_context()
+    entities = [mock.MagicMock()]
+
+    mock_fetch_zones.return_value = ["zone-a", "zone-b"]
+    mock_generic_paging.side_effect = [entities, ConnectionError("zone-b failed")]
+
+    svc_def = GCPService(service="gce_instance")
+
+    result = asyncio.run(gce_instance.get_gce_instance_entity(ctx, "my_project", svc_def))
+
+    assert list(result) == entities


### PR DESCRIPTION
## problem

`get_gce_instance_entity` fans out one `generic_paging` task per zone with `asyncio.gather(return_exceptions=True)`, then does `all_results.extend(result)` for every element

`generic_paging` issues its first request outside a `try`, so a transient error on one zone (timeout, `ClientConnectorError`) surfaces as an element of `results`. `list.extend(<exception>)` then raises `TypeError: 'X' object is not iterable`, which the extractor decorator catches, so **all** gce_instance entities for that project are dropped that cycle. the `return_exceptions=True` was meant to make this resilient

## fix

skip exception results and log them before extending, matching the other `gather(return_exceptions=True)` sites in the codebase (`log_integration_service.py`, `metric_ingest.py`)

## how tested

added a unit test that mocks two zones where the second paging task raises, asserting the extractor returns the first zone's entities instead of raising. it fails with the TypeError on the old code and passes on the new
