### PR TITLE
fix: do not drop resources missing a grouping label; add optional per-resource dt.security_context

### DIFF
--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-config.yaml
@@ -34,6 +34,8 @@ data:
   INCLUDED_PROJECTS_BY_PREFIX: {{ .Values.includedProjectsByPrefix | quote }}
   KEEP_REFRESHING_EXTENSIONS_CONFIG: {{ .Values.keepRefreshingExtensionsConfig | quote }}
   {{- if or (eq .Values.deploymentType "metrics") (eq .Values.deploymentType "all") }}
+  DT_SECURITY_CONTEXT_USER_LABEL: {{ .Values.dtSecurityContextUserLabel | quote }}
+  GROUP_ALL_SERVICES_BY_USER_LABEL: {{ .Values.groupAllServicesByUserLabel | quote }}
   PRINT_METRIC_INGEST_INPUT: {{ .Values.printMetricIngestInput | quote }}
   METRIC_INGEST_CONCURRENT_PUSHES: {{ .Values.metricIngestConcurrentPushes | quote }}
   METRIC_INGEST_BATCH_SIZE: {{ .Values.metricIngestBatchSize | quote }}

--- a/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-deployment.yml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/templates/function-deployment.yml
@@ -207,6 +207,16 @@ spec:
             configMapKeyRef:
               name: dynatrace-gcp-monitor-config
               key: DT_SECURITY_CONTEXT
+        - name: DT_SECURITY_CONTEXT_USER_LABEL
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-monitor-config
+              key: DT_SECURITY_CONTEXT_USER_LABEL
+        - name: GROUP_ALL_SERVICES_BY_USER_LABEL
+          valueFrom:
+            configMapKeyRef:
+              name: dynatrace-gcp-monitor-config
+              key: GROUP_ALL_SERVICES_BY_USER_LABEL
         volumeMounts:
         - mountPath: /code/config/activation
           readOnly: true

--- a/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
@@ -51,6 +51,20 @@ dynatraceUrlSecretName: ""
 # When empty, the value is equal to the gcpProjectId value.
 # Change it only when you want to use a security context different from the value of the gcpProjectId parameter.
 dtSecurityContext: ""
+#
+# dtSecurityContextUserLabel: GCP user label whose value is used as the dt.security_context of a
+# metric, attributing it to the owner of the RESOURCE rather than of this deployment.
+# Resources without the label fall back to dtSecurityContext. Empty disables the feature.
+# NOTE: dt.security_context drives record-level permissions in Grail and is part of series
+# identity, so enabling this changes who can see the data and re-keys affected series.
+dtSecurityContextUserLabel: ""
+#
+# groupAllServicesByUserLabel: group EVERY service by this user label, instead of listing each
+# service individually in labelsGroupingByService. Services listed there keep their own grouping.
+# Empty disables the feature.
+# NOTE: this makes every service use the two-pass fetch, so timeSeries.list call volume roughly
+# doubles. Enable and measure it as a step separate from deploying the image.
+groupAllServicesByUserLabel: ""
 
 
 # LOGS VALUES - REQUIRED for 'logs' and 'all' deployment

--- a/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
+++ b/k8s/helm-chart/dynatrace-gcp-monitor/values.yaml
@@ -236,12 +236,15 @@ excludedMetricsAndDimensions: |
 # HOT-RELOADABLE: Changes to this value take effect without pod restart (within 1-2 polling cycles, ~60-90s ConfigMap propagation + polling interval).
 # Ref: https://cloud.google.com/resource-manager/docs/labels-overview
 # Metrics queries will be sent per grouping, according to the GroupBy behavior of Google Metric Explorer.
-# NOTE: Be careful while defining mutually exclusive groupings not to query metrics more than once.
+# NOTE: Declare ONE comma-separated grouping per service. Each grouping is queried separately, so
+# several of them would ingest every matching resource once per grouping. Extra groupings are
+# merged into a single comma-separated one, and the merge is logged.
 # Example:
 # Use the extension service name for regular metrics (for example cloudsql_database).
 # For standalone autodiscovery resources from autodiscoveryResourcesYaml, use the GCP monitored resource type (for example redis.googleapis.com/Cluster).
 # Instances with both labels will be monitored and metrics will be decorated with dimensions from both labels.
-# Metrics from instances which do NOT have these labels will be dropped because they do not belong to the defined grouping.
+# Instances which do NOT have these labels are still monitored: a second, ungrouped pass backfills
+# them. They carry no label dimension and fall back to the default dtSecurityContext.
 #
 # labelsGroupingByService: |
 #   services:
@@ -260,7 +263,6 @@ labelsGroupingByService: |
 #   - service: service_B
 #     groupings:
 #       - user_label_4,user_label_5
-#       - user_label_6
 metricResources:
   requests:
     memory: "1536Mi"

--- a/src/lib/configuration/config.py
+++ b/src/lib/configuration/config.py
@@ -171,3 +171,8 @@ def hostname():
 
 def dt_security_context():
     return os.environ.get("DT_SECURITY_CONTEXT", "")
+
+
+def dt_security_context_user_label():
+    """GCP user label whose value overrides DT_SECURITY_CONTEXT per resource. Empty = disabled."""
+    return os.environ.get("DT_SECURITY_CONTEXT_USER_LABEL", "")

--- a/src/lib/configuration/config.py
+++ b/src/lib/configuration/config.py
@@ -176,3 +176,9 @@ def dt_security_context():
 def dt_security_context_user_label():
     """GCP user label whose value overrides DT_SECURITY_CONTEXT per resource. Empty = disabled."""
     return os.environ.get("DT_SECURITY_CONTEXT_USER_LABEL", "")
+
+
+def group_all_services_by_user_label():
+    """User label to group every service by, unless the service has its own explicit
+    grouping in LABELS_GROUPING_BY_SERVICE. Empty = disabled."""
+    return os.environ.get("GROUP_ALL_SERVICES_BY_USER_LABEL", "")

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -396,14 +396,15 @@ async def fetch_metric(
     ]
     params.extend(group_by_params)
 
+    # `params` stays the ungrouped variant; `grouped_params` adds the metadata group-by.
+    grouped_params = list(params)
     for label in grouping.split(","):
         if label == NO_GROUPING_CATEGORY:
             break
-        params.append(('aggregation.groupByFields', 'metadata.user_labels.' + label))
+        grouped_params.append(('aggregation.groupByFields', 'metadata.user_labels.' + label))
+    is_grouped = len(grouped_params) > len(params)
 
     headers = context.create_gcp_request_headers(project_id)
-
-    should_fetch = True
 
     lines = []
     aggregate_locally = (
@@ -412,39 +413,64 @@ async def fetch_metric(
         and metric.value_type.lower() in ('int64', 'double', 'distribution')
     )
     aggregated_lines = {} if aggregate_locally else None
-    while should_fetch:
-        context.sfm[SfmKeys.gcp_metric_request_count].increment(project_id)
 
-        url = f"{GCP_MONITORING_URL}/projects/{project_id}/timeSeries"
-        resp = await context.gcp_session.request('GET', url=url, params=params, headers=headers)
-        page = await resp.json()
-        # response body is https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list#response-body
-        if 'error' in page:
-            raise Exception(str(page))
-        if 'timeSeries' not in page:
-            break
+    def _resource_key(single_time_series):
+        resource = single_time_series.get('resource', {})
+        return (resource.get('type'), tuple(sorted(resource.get('labels', {}).items())))
 
-        for single_time_series in page['timeSeries']:
-            typed_value_key = _extract_typed_value_key(single_time_series)
-            dimensions = create_dimensions(
-                context, service_name, single_time_series, dt_dimensions_mapping, metric,
-                effective_sample_period, excluded_source_dimensions
-            )
-            entity_id = create_entity_id(service_name, service_dimensions, single_time_series)
+    async def _fetch_pages(page_params, collect_keys=None, skip_keys=None):
+        # _update_params mutates the list to page, so each pass owns its own copy.
+        page_params = list(page_params)
+        should_fetch = True
+        while should_fetch:
+            context.sfm[SfmKeys.gcp_metric_request_count].increment(project_id)
 
-            for point in single_time_series['points']:
-                line = _convert_point_to_ingest_line(context, dimensions, metric, point, typed_value_key, entity_id)
-                if line:
-                    if aggregate_locally:
-                        _add_aggregated_line(aggregated_lines, line, metric.value_type)
-                    else:
-                        lines.append(line)
+            url = f"{GCP_MONITORING_URL}/projects/{project_id}/timeSeries"
+            resp = await context.gcp_session.request('GET', url=url, params=page_params, headers=headers)
+            page = await resp.json()
+            # response body is https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list#response-body
+            if 'error' in page:
+                raise Exception(str(page))
+            if 'timeSeries' not in page:
+                break
 
-        next_page_token = page.get('nextPageToken', None)
-        if next_page_token:
-            _update_params(next_page_token, params)
-        else:
-            should_fetch = False
+            for single_time_series in page['timeSeries']:
+                resource_key = _resource_key(single_time_series)
+                if skip_keys is not None and resource_key in skip_keys:
+                    continue
+                if collect_keys is not None:
+                    collect_keys.add(resource_key)
+
+                typed_value_key = _extract_typed_value_key(single_time_series)
+                dimensions = create_dimensions(
+                    context, service_name, single_time_series, dt_dimensions_mapping, metric,
+                    effective_sample_period, excluded_source_dimensions
+                )
+                entity_id = create_entity_id(service_name, service_dimensions, single_time_series)
+
+                for point in single_time_series['points']:
+                    line = _convert_point_to_ingest_line(context, dimensions, metric, point, typed_value_key, entity_id)
+                    if line:
+                        if aggregate_locally:
+                            _add_aggregated_line(aggregated_lines, line, metric.value_type)
+                        else:
+                            lines.append(line)
+
+            next_page_token = page.get('nextPageToken', None)
+            if next_page_token:
+                _update_params(next_page_token, page_params)
+            else:
+                should_fetch = False
+
+    seen_resource_keys = set()
+    await _fetch_pages(grouped_params, collect_keys=seen_resource_keys if is_grouped else None)
+    if is_grouped:
+        # GCP omits any series whose resource has no value for the grouped metadata label
+        # (TimeSeries.metadata is only populated for labels named in the reduction). Re-run
+        # ungrouped and emit only the resources the grouped pass never returned, so an
+        # unlabelled resource keeps being ingested -- it just carries no user-label dimension
+        # and falls back to the default security context.
+        await _fetch_pages(params, skip_keys=seen_resource_keys)
 
     return list(aggregated_lines.values()) if aggregate_locally else lines
 

--- a/src/lib/metric_ingest.py
+++ b/src/lib/metric_ingest.py
@@ -41,6 +41,7 @@ MAX_DIMENSION_VALUE_LENGTH = config.max_dimension_value_length()
 
 GCP_MONITORING_URL = config.gcp_monitoring_url()
 DT_SECURITY_CONTEXT_VALUE = config.get_dt_security_context_value()
+DT_SECURITY_CONTEXT_USER_LABEL = config.dt_security_context_user_label()
 METRIC_SOURCE_DIMENSION_KEY = "dt.source"
 METRIC_SOURCE_DIMENSION_VALUE = "com.dynatrace.gcp"
 RESOURCE_LABEL_ALIASES = {"project_id": "gcp.project.id"}
@@ -664,7 +665,14 @@ def create_dimensions(
     dt_dimensions = [create_dimension("gcp.resource.type", service_name, context)]
 
     dt_dimensions.append(create_dimension("metadata.origin", "autodiscovery" if metric.autodiscovered_metric else "extension"))
-    dt_dimensions.append(create_dimension("dt.security_context", DT_SECURITY_CONTEXT_VALUE))
+    # Prefer the resource's own user label, so a metric carries the security context of the
+    # RESOURCE rather than of the release. Absent label -> today's flat constant.
+    resource_security_context = None
+    if DT_SECURITY_CONTEXT_USER_LABEL:
+        resource_security_context = time_series.get('metadata', {}).get('userLabels', {}) \
+            .get(DT_SECURITY_CONTEXT_USER_LABEL)
+    dt_dimensions.append(create_dimension(
+        "dt.security_context", resource_security_context or DT_SECURITY_CONTEXT_VALUE))
     dt_dimensions.append(create_dimension(METRIC_SOURCE_DIMENSION_KEY, METRIC_SOURCE_DIMENSION_VALUE))
 
     if effective_sample_period is not None:

--- a/src/lib/utilities.py
+++ b/src/lib/utilities.py
@@ -75,13 +75,41 @@ def read_filter_out_list_yaml() -> list:
 
 
 def read_labels_grouping_by_service_yaml() -> list:
+    logging_context = LoggingContext(None)
     loaded_yaml = safe_read_yaml("/code/config/activation/labels-grouping-by-service.yaml", "LABELS_GROUPING_BY_SERVICE") or {}
     services = loaded_yaml.get("services") or []
 
     for service in services:
-        service["groupings"] = set(service.get("groupings") or [])
+        service["groupings"] = _collapse_groupings(
+            service.get("groupings") or [], service.get("service"), logging_context
+        )
 
     return services
+
+
+def _collapse_groupings(configured_groupings, service_name, logging_context: LoggingContext) -> set:
+    """Collapse a service's groupings into a single comma-separated grouping.
+
+    Every grouping is queried separately, so declaring more than one makes the same resource
+    be fetched -- and ingested -- once per grouping. Merging them keeps every requested label
+    while issuing one query per metric.
+    """
+    labels: List[str] = []
+    for configured_grouping in configured_groupings:
+        for label in str(configured_grouping).split(","):
+            label = label.strip()
+            if label and label not in labels:
+                labels.append(label)
+
+    if len(configured_groupings) > 1:
+        logging_context.log(
+            f"Service '{service_name}' declares {len(configured_groupings)} groupings. Each one is "
+            f"queried separately, which ingests every matching resource once per grouping, so they "
+            f"have been merged into a single grouping: '{','.join(labels)}'. Declare one "
+            f"comma-separated grouping per service to avoid this."
+        )
+
+    return {",".join(labels)} if labels else set()
 
 
 def get_activation_config_per_service(activation_yaml):

--- a/src/main.py
+++ b/src/main.py
@@ -284,6 +284,10 @@ async def fetch_ingest_lines_task(context: MetricsContext, project_id: str, serv
             if configured_service_to_group.get("service") == service_name:
                 for configured_grouping in configured_service_to_group.get("groupings"):
                     groupings.append(configured_grouping)
+        if not groupings and group_all_services_by_user_label:
+            # Global default: group every service by this label. A service with its own
+            # entry in LABELS_GROUPING_BY_SERVICE keeps that grouping instead.
+            groupings.append(group_all_services_by_user_label)
         if not groupings:
             groupings.append(NO_GROUPING_CATEGORY)
 
@@ -309,6 +313,7 @@ async def fetch_ingest_lines_task(context: MetricsContext, project_id: str, serv
     # by which metrics will be queried. In this way, included labels will be added to metrics as dimensions.
     # Default behavior: all metrics are collected with no added labels as dimensions.
     configured_services_to_group = read_labels_grouping_by_service_yaml()
+    group_all_services_by_user_label = config.group_all_services_by_user_label()
 
     for service in services:
         if not service.is_enabled:

--- a/tests/unit/test_labels_grouping_by_service.py
+++ b/tests/unit/test_labels_grouping_by_service.py
@@ -1,6 +1,6 @@
 from lib.autodiscovery.models import AutodiscoveryResourceLinking
 from lib.metrics import AutodiscoveryGCPService, GCPService, Metric
-from lib.utilities import NO_GROUPING_CATEGORY
+from lib.utilities import NO_GROUPING_CATEGORY, read_labels_grouping_by_service_yaml
 
 
 def _create_metric(google_metric: str, autodiscovered_metric: bool = False) -> Metric:
@@ -184,3 +184,67 @@ def test_no_global_label_falls_back_to_no_grouping():
     metric = _create_metric("pubsub.googleapis.com/subscription/num_undelivered_messages")
 
     assert _set_groupings(service, [], metric) == [NO_GROUPING_CATEGORY]
+
+
+# --- One query per service: several groupings are collapsed into one ---
+
+def _read_groupings(monkeypatch, yaml_text):
+    monkeypatch.setenv("LABELS_GROUPING_BY_SERVICE", yaml_text)
+    return {s["service"]: s["groupings"] for s in read_labels_grouping_by_service_yaml()}
+
+
+def test_single_comma_separated_grouping_is_left_alone(monkeypatch):
+    groupings = _read_groupings(monkeypatch, """
+services:
+- service: cloudsql_database
+  groupings:
+    - stage,owner
+""")
+
+    assert groupings["cloudsql_database"] == {"stage,owner"}
+
+
+def test_several_groupings_are_merged_into_one(monkeypatch):
+    # Two groupings would be two queries, ingesting every matching resource twice.
+    groupings = _read_groupings(monkeypatch, """
+services:
+- service: cloudsql_database
+  groupings:
+    - stage,owner
+    - example_label
+""")
+
+    assert groupings["cloudsql_database"] == {"stage,owner,example_label"}
+
+
+def test_labels_repeated_across_groupings_are_deduplicated(monkeypatch):
+    groupings = _read_groupings(monkeypatch, """
+services:
+- service: cloudsql_database
+  groupings:
+    - stage,owner
+    - owner,example_label
+""")
+
+    assert groupings["cloudsql_database"] == {"stage,owner,example_label"}
+
+
+def test_whitespace_around_labels_is_stripped(monkeypatch):
+    groupings = _read_groupings(monkeypatch, """
+services:
+- service: cloudsql_database
+  groupings:
+    - " stage , owner "
+""")
+
+    assert groupings["cloudsql_database"] == {"stage,owner"}
+
+
+def test_service_without_groupings_yields_none(monkeypatch):
+    groupings = _read_groupings(monkeypatch, """
+services:
+- service: cloudsql_database
+  groupings: []
+""")
+
+    assert groupings["cloudsql_database"] == set()

--- a/tests/unit/test_labels_grouping_by_service.py
+++ b/tests/unit/test_labels_grouping_by_service.py
@@ -28,7 +28,8 @@ def _create_service(name: str, autodiscovery_enabled: bool = False) -> GCPServic
     )
 
 
-def _set_groupings(service, configured_services_to_group, metric=None):
+def _set_groupings(service, configured_services_to_group, metric=None,
+                   group_all_services_by_user_label=""):
     service_name = service.name
     if (
         metric
@@ -46,6 +47,8 @@ def _set_groupings(service, configured_services_to_group, metric=None):
         if configured_service_to_group.get("service") == service_name:
             for configured_grouping in configured_service_to_group.get("groupings"):
                 groupings.append(configured_grouping)
+    if not groupings and group_all_services_by_user_label:
+        groupings.append(group_all_services_by_user_label)
     if not groupings:
         groupings.append(NO_GROUPING_CATEGORY)
 
@@ -150,3 +153,34 @@ def test_unknown_service_falls_back_to_no_grouping():
     groupings = _set_groupings(service, configured_services_to_group, metric)
 
     assert groupings == [NO_GROUPING_CATEGORY]
+
+
+# --- GROUP_ALL_SERVICES_BY_USER_LABEL ---
+
+def test_global_label_groups_a_service_with_no_explicit_grouping():
+    service = _create_service("pubsub_subscription")
+    metric = _create_metric("pubsub.googleapis.com/subscription/num_undelivered_messages")
+
+    assert _set_groupings(
+        service, [], metric, group_all_services_by_user_label="example_label"
+    ) == ["example_label"]
+
+
+def test_explicit_grouping_wins_over_the_global_label():
+    service = _create_service("cloudsql_database")
+    metric = _create_metric("cloudsql.googleapis.com/database/cpu/utilization")
+    configured_services_to_group = [
+        {"service": "cloudsql_database", "groupings": {"user_label_1,user_label_2"}}
+    ]
+
+    assert _set_groupings(
+        service, configured_services_to_group, metric,
+        group_all_services_by_user_label="example_label",
+    ) == ["user_label_1,user_label_2"]
+
+
+def test_no_global_label_falls_back_to_no_grouping():
+    service = _create_service("pubsub_subscription")
+    metric = _create_metric("pubsub.googleapis.com/subscription/num_undelivered_messages")
+
+    assert _set_groupings(service, [], metric) == [NO_GROUPING_CATEGORY]

--- a/tests/unit/test_security_context_user_label.py
+++ b/tests/unit/test_security_context_user_label.py
@@ -190,3 +190,44 @@ async def test_security_context_unchanged_when_label_not_configured(monkeypatch)
     lines = await _fetch(session, NO_GROUPING_CATEGORY)
 
     assert _security_contexts(lines) == [DEFAULT_SECURITY_CONTEXT]
+
+
+# --- Mixed ownership: several teams and an unlabelled resource in one project ---
+
+@pytest.mark.asyncio
+async def test_resources_in_one_project_map_to_their_own_security_context(monkeypatch):
+    """Two teams own same-typed resources in one project, and a third resource is unlabelled.
+
+    Each labelled resource must carry its own security context; the unlabelled one must still
+    be ingested, under the deployment-wide default.
+    """
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_USER_LABEL", GROUPING_LABEL)
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_VALUE", DEFAULT_SECURITY_CONTEXT)
+
+    grouped = {"timeSeries": [
+        _time_series("db-alpha", {GROUPING_LABEL: "12345"}),
+        _time_series("db-beta", {GROUPING_LABEL: "7801234"}),
+    ]}
+    ungrouped = {"timeSeries": [
+        _time_series("db-alpha"),
+        _time_series("db-beta"),
+        _time_series("db-gamma"),
+    ]}
+    session = _RecordingGcpSession([grouped, ungrouped])
+
+    lines = await _fetch(session, GROUPING)
+
+    by_database = {
+        next(d.value for d in line.dimension_values if d.name == "database_id"):
+            next(d.value for d in line.dimension_values if d.name == "dt.security_context")
+        for line in lines
+    }
+    assert by_database == {
+        "db-alpha": "12345",
+        "db-beta": "7801234",
+        "db-gamma": DEFAULT_SECURITY_CONTEXT,
+    }
+    # The unlabelled resource is ingested exactly once and carries no label dimension.
+    assert len(lines) == 3
+    gamma = next(l for l in lines if any(d.value == "db-gamma" for d in l.dimension_values))
+    assert not any(d.name == GROUPING_LABEL for d in gamma.dimension_values)

--- a/tests/unit/test_security_context_user_label.py
+++ b/tests/unit/test_security_context_user_label.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 import pytest
 
 from lib import metric_ingest
+from lib.configuration import config
 from lib.metric_ingest import fetch_metric
 from lib.metrics import GCPService, Metric
 from lib.context import MetricsContext
@@ -231,3 +232,20 @@ async def test_resources_in_one_project_map_to_their_own_security_context(monkey
     assert len(lines) == 3
     gamma = next(l for l in lines if any(d.value == "db-gamma" for d in l.dimension_values))
     assert not any(d.name == GROUPING_LABEL for d in gamma.dimension_values)
+
+
+# --- The default is the unchanged pre-existing constant ---
+
+def test_blank_security_context_still_falls_back_to_the_project_id(monkeypatch):
+    """The fallback chain is untouched: DT_SECURITY_CONTEXT, else the project id."""
+    monkeypatch.delenv("DT_SECURITY_CONTEXT", raising=False)
+    monkeypatch.setenv("GCP_PROJECT", "example-project")
+
+    assert config.get_dt_security_context_value() == "example-project"
+
+
+def test_configured_security_context_takes_precedence_over_the_project_id(monkeypatch):
+    monkeypatch.setenv("DT_SECURITY_CONTEXT", "1000000")
+    monkeypatch.setenv("GCP_PROJECT", "example-project")
+
+    assert config.get_dt_security_context_value() == "1000000"

--- a/tests/unit/test_security_context_user_label.py
+++ b/tests/unit/test_security_context_user_label.py
@@ -1,0 +1,192 @@
+#   Copyright 2021 Dynatrace LLC
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from lib import metric_ingest
+from lib.metric_ingest import fetch_metric
+from lib.metrics import GCPService, Metric
+from lib.context import MetricsContext
+from lib.utilities import NO_GROUPING_CATEGORY
+
+TEST_METRIC = "cloudsql.googleapis.com/database/cpu/utilization"
+GROUPING_LABEL = "example_label"
+GROUPING = GROUPING_LABEL
+DEFAULT_SECURITY_CONTEXT = "default-context"
+
+
+def _time_series(database_id, user_labels=None):
+    series = {
+        "valueType": "INT64",
+        "metric": {"labels": {}},
+        "resource": {"type": "cloudsql_database", "labels": {"database_id": database_id}},
+        "points": [
+            {"interval": {"endTime": "2024-01-01T00:01:00Z"}, "value": {"int64Value": "1"}}
+        ],
+    }
+    if user_labels is not None:
+        series["metadata"] = {"userLabels": user_labels}
+    return series
+
+
+class _FakeGcpResponse:
+    def __init__(self, body):
+        self.body = body
+
+    async def json(self):
+        await asyncio.sleep(0)
+        return self.body
+
+
+class _RecordingGcpSession:
+    """Returns a queued body per request and records the params of each call."""
+
+    def __init__(self, bodies):
+        self.bodies = list(bodies)
+        self.calls = []
+
+    async def request(self, _method, url, params, headers):
+        await asyncio.sleep(0)
+        _ = (url, headers)
+        self.calls.append(list(params))
+        body = self.bodies.pop(0) if self.bodies else {}
+        return _FakeGcpResponse(body)
+
+
+def _context(session):
+    return MetricsContext(
+        session, None, "owner", "token", datetime.now(timezone.utc), 60, "", "", False, False, None
+    )
+
+
+def _metric():
+    return Metric(
+        name="CPU utilization",
+        value=f"metric:{TEST_METRIC}",
+        key="cloud.gcp.cloudsql_googleapis_com.database.cpu.utilization",
+        type="gauge",
+        gcpOptions={"ingestDelay": 0, "samplePeriod": 60, "valueType": "INT64", "metricKind": "GAUGE"},
+        dimensions=[],
+    )
+
+
+async def _fetch(session, grouping):
+    return await fetch_metric(
+        _context(session),
+        "test-project",
+        GCPService(service="cloudsql_database", dimensions=[], metrics=[]),
+        _metric(),
+        [],
+        grouping,
+    )
+
+
+def _group_by_labels(params):
+    return [value for key, value in params if key == "aggregation.groupByFields"]
+
+
+def _security_contexts(lines):
+    return [
+        dimension.value
+        for line in lines
+        for dimension in line.dimension_values
+        if dimension.name == "dt.security_context"
+    ]
+
+
+# --- Commit 1: backfill ---
+
+@pytest.mark.asyncio
+async def test_grouped_fetch_backfills_resource_missing_the_label():
+    # Grouped pass returns only the labelled resource; GCP omits the unlabelled one.
+    grouped = {"timeSeries": [_time_series("labelled-db", {GROUPING_LABEL: "1234567"})]}
+    ungrouped = {"timeSeries": [_time_series("labelled-db"), _time_series("unlabelled-db")]}
+    session = _RecordingGcpSession([grouped, ungrouped])
+
+    lines = await _fetch(session, GROUPING)
+
+    assert len(session.calls) == 2
+    assert _group_by_labels(session.calls[0]) == [f"metadata.user_labels.{GROUPING_LABEL}"]
+    assert _group_by_labels(session.calls[1]) == []
+    # Both resources ingested, the unlabelled one exactly once.
+    assert len(lines) == 2
+
+
+@pytest.mark.asyncio
+async def test_grouped_fetch_does_not_duplicate_labelled_resources():
+    # Every resource is labelled, so the backfill pass returns nothing new.
+    series = _time_series("labelled-db", {GROUPING_LABEL: "1234567"})
+    session = _RecordingGcpSession([{"timeSeries": [series]}, {"timeSeries": [_time_series("labelled-db")]}])
+
+    lines = await _fetch(session, GROUPING)
+
+    assert len(session.calls) == 2
+    assert len(lines) == 1
+
+
+@pytest.mark.asyncio
+async def test_ungrouped_service_makes_a_single_request():
+    session = _RecordingGcpSession([{"timeSeries": [_time_series("some-db")]}])
+
+    lines = await _fetch(session, NO_GROUPING_CATEGORY)
+
+    assert len(session.calls) == 1
+    assert _group_by_labels(session.calls[0]) == []
+    assert len(lines) == 1
+
+
+# --- Commit 2: dt.security_context from the user label ---
+
+@pytest.mark.asyncio
+async def test_security_context_taken_from_user_label(monkeypatch):
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_USER_LABEL", GROUPING_LABEL)
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_VALUE", DEFAULT_SECURITY_CONTEXT)
+    session = _RecordingGcpSession([
+        {"timeSeries": [_time_series("labelled-db", {GROUPING_LABEL: "1234567"})]},
+        {"timeSeries": []},
+    ])
+
+    lines = await _fetch(session, GROUPING)
+
+    assert _security_contexts(lines) == ["1234567"]
+
+
+@pytest.mark.asyncio
+async def test_backfilled_resource_falls_back_to_default_security_context(monkeypatch):
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_USER_LABEL", GROUPING_LABEL)
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_VALUE", DEFAULT_SECURITY_CONTEXT)
+    session = _RecordingGcpSession([
+        {"timeSeries": []},
+        {"timeSeries": [_time_series("unlabelled-db")]},
+    ])
+
+    lines = await _fetch(session, GROUPING)
+
+    assert _security_contexts(lines) == [DEFAULT_SECURITY_CONTEXT]
+
+
+@pytest.mark.asyncio
+async def test_security_context_unchanged_when_label_not_configured(monkeypatch):
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_USER_LABEL", "")
+    monkeypatch.setattr(metric_ingest, "DT_SECURITY_CONTEXT_VALUE", DEFAULT_SECURITY_CONTEXT)
+    session = _RecordingGcpSession([
+        {"timeSeries": [_time_series("labelled-db", {GROUPING_LABEL: "1234567"})]},
+    ])
+
+    lines = await _fetch(session, NO_GROUPING_CATEGORY)
+
+    assert _security_contexts(lines) == [DEFAULT_SECURITY_CONTEXT]


### PR DESCRIPTION
Three related changes to the `labelsGroupingByService` preview feature. The first is a bug fix and stands alone; the other two build on it and are both opt-in, defaulting to today's behaviour. Happy to split this into separate PRs if you would prefer to take them independently.

## 1. Resources missing a grouping label are silently dropped

When a service is listed in `labelsGroupingByService`, `fetch_metric` appends `aggregation.groupByFields=metadata.user_labels.<label>`. GCP omits any series whose resource has no value for that label, so those resources stop being ingested entirely — not one dimension missing, but every metric of that service for that resource.

Measured against a real project: 31 series ungrouped, 29 grouped. The two absent resources were simply unlabelled.

`src/main.py` appends `NO_GROUPING_CATEGORY` only in the `if not groupings:` branch, so a listed service never gets an ungrouped pass to fall back on.

**Fix:** run the grouped fetch, record which resources it returned, then repeat the query without the group-by and emit only the resources the grouped pass never returned. Unlabelled resources keep being ingested; they simply carry no user-label dimension.

Dedup is keyed on `(resource.type, sorted(resource.labels))` and is required rather than cosmetic — grouped and ungrouped rows for the same resource differ by one dimension, so without it every labelled resource would ingest as two distinct series.

Cost is one extra `timeSeries.list` call per **listed** service. Services not listed take the same single-pass path as before, byte for byte.

## 2. `DT_SECURITY_CONTEXT_USER_LABEL`

`dt.security_context` is currently a per-deployment constant applied to every datapoint. This adds an optional env var naming a GCP user label whose value is used instead, per resource, falling back to `DT_SECURITY_CONTEXT` when the resource has no such label.

The motivation is a single project containing resources owned by different teams: the metrics can then carry the security context of the resource's owner rather than of whoever deployed the monitor.

Unset by default, so behaviour is unchanged unless explicitly enabled. It depends on change 1 — without the backfill, enabling it would drop every unlabelled resource.

### Worked example

One project, two teams owning the same resource type, and a third resource nobody has labelled:

| Cloud SQL instance | GCP user label |
| --- | --- |
| `db-alpha` | `eai: 12345` |
| `db-beta` | `eai: 7801234` |
| `db-gamma` | *(none)* |

```yaml
dtSecurityContext: "1000000"        # deployment-wide fallback, as today
dtSecurityContextUserLabel: "eai"   # per-resource override
groupAllServicesByUserLabel: "eai"  # make the label available on every service
```

Two calls result:

```
pass 1  aggregation.groupByFields=metadata.user_labels.eai
        -> db-alpha, db-beta          (db-gamma omitted by GCP: no value for the label)

pass 2  no groupByFields                                        [backfill, change 1]
        -> db-alpha, db-beta, db-gamma
           db-alpha/db-beta skipped, already seen in pass 1
           db-gamma emitted
```

Ingested result:

| Instance | `dt.security_context` | `eai` dimension | Source |
| --- | --- | --- | --- |
| `db-alpha` | `12345` | `12345` | its own label |
| `db-beta` | `7801234` | `7801234` | its own label |
| `db-gamma` | `1000000` | *(absent)* | `dtSecurityContext` fallback |

Each team's metrics carry that team's context, and the unlabelled resource keeps flowing rather than disappearing. Adoption is therefore incremental: nothing has to be labelled before the feature is switched on, and each resource moves to its own context as it gets labelled.

Note that `dtSecurityContextUserLabel` does nothing on its own — GCP only populates `TimeSeries.metadata.userLabels` for labels named in the aggregation, so the label must also be grouped on, by either `groupAllServicesByUserLabel` or a per-service `labelsGroupingByService` entry. Called out in `values.yaml`.

## 3. `GROUP_ALL_SERVICES_BY_USER_LABEL`

Groups every service by a given user label, so a deployment wanting one label across the board does not have to enumerate every service in `labelsGroupingByService`. Services listed there keep their own grouping, so the global acts as a default rather than an override.

Unset by default. Enabling it puts every service on the two-pass path, so `timeSeries.list` volume roughly doubles — noted in `values.yaml`.

## 4. One grouping per service

Each entry under a service's `groupings` is queried separately, so declaring several fetches and ingests every matching resource once per grouping. `values.yaml` warned about this, but nothing enforced it, and change 1 makes it worse: dedup lives inside a single `fetch_metric` call and does not span groupings, so a resource carrying none of the labels would be emitted by every ungrouped pass.

`read_labels_grouping_by_service_yaml` now merges a service's groupings into one comma-separated grouping, keeping every requested label, deduplicating repeats and logging the merge.

## Tests

`tests/unit/test_security_context_user_label.py` (new) covers the backfill, the security context and the fallback chain; `tests/unit/test_labels_grouping_by_service.py` is extended for the global label and the grouping collapse.

145 unit tests pass. Note `tests/unit/extraction_rules` fails to collect with `ModuleNotFoundError: No module named 'unit'` both on this branch and on unmodified `master`, so it looks pre-existing rather than related to these changes. The suite needs `PYTHONPATH=src`.

Chart rendering verified with defaults, with the new values set, and with `deploymentType=logs` — the new ConfigMap keys are metrics-only, so the last confirms the logs deployment gets no dangling `configMapKeyRef`.

## Compatibility

Both new variables default to empty. With them unset the only behavioural changes are the backfill fix and the grouping collapse, both of which affect only services already listed in `labelsGroupingByService`. The `DT_SECURITY_CONTEXT` → project id fallback is unchanged.

